### PR TITLE
Argument display=FALSE to transform_mathjax() - inline/display equations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: equatags
 Type: Package
 Title: Equations to 'XML'
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("David", "Gohel", role = c("aut", "cre"),
     email = "david.gohel@ardata.fr"),
@@ -16,6 +16,6 @@ BugReports: https://github.com/ardata-fr/equatags/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Depends: R (>= 4.0.0)
 Imports: xml2, xslt, tools, katex

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
+# equatags 0.2.1
+
+\*.add a display= argument to transform_mathjax() to allow generating display or inline equations. It is set to FALSE by default (inline equation). This changes the behaviour that was previously to generate display equations only.
+
 # equatags 0.2.0
 
-* drop the node.js dependency in favor of package katex.
+-   drop the node.js dependency in favor of package katex.
 
 # equatags 0.1.1
 
-* use tools::R_user_dir instead of rappdirs::user_data_dir as it's a condition to keep the package on CRAN ("This is using ^~/.local/share/equatags , prohibited by the CRAN policy.  Please replace the use of rappdirs by the allowed procedure documented there.")
+-   use tools::R_user_dir instead of rappdirs::user_data_dir as it's a condition to keep the package on CRAN ("This is using \^\~/.local/share/equatags , prohibited by the CRAN policy. Please replace the use of rappdirs by the allowed procedure documented there.")

--- a/R/write_mathjax.R
+++ b/R/write_mathjax.R
@@ -20,6 +20,8 @@ xml_header <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 #' of 'MathJax' equations.
 #' @param x MathJax equations
 #' @param to output format, one of 'html' or 'mml'
+#' @param display should the equation be in display (`TRUE`) or inline mode
+#' (`FALSE`, by default)
 #' @return a character vector that contains 'html' or 'mml'
 #' codes corresponding to the equations.
 #' @examples
@@ -31,7 +33,7 @@ xml_header <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 #' cat(z, sep = "\n\n")
 #' @importFrom xml2 read_xml xml_children
 #' @importFrom katex katex_mathml katex_html
-transform_mathjax <- function(x, to = "html"){
+transform_mathjax <- function(x, to = "html", display = FALSE){
 
   if(length(x) < 1) return(character(0))
   to <- match.arg(to, choices = c("html", "mml", "svg"), several.ok = FALSE)
@@ -43,7 +45,8 @@ transform_mathjax <- function(x, to = "html"){
     info <- gsub("<span class=\"katex\">", "", info, fixed = TRUE)
     info <- vapply(info, mml_to_ooml, FUN.VALUE = character(1L), USE.NAMES = FALSE)
   } else {
-    info <- vapply(x, katex_html, "", preview = FALSE, include_css = TRUE)
+    info <- vapply(x, katex_html, "", preview = FALSE, include_css = TRUE,
+      displayMode = display)
     names(info) <- NULL
   }
 

--- a/man/transform_mathjax.Rd
+++ b/man/transform_mathjax.Rd
@@ -4,12 +4,15 @@
 \alias{transform_mathjax}
 \title{'MathJax' equation as 'HTML' or 'MathML'.}
 \usage{
-transform_mathjax(x, to = "html")
+transform_mathjax(x, to = "html", display = FALSE)
 }
 \arguments{
 \item{x}{MathJax equations}
 
 \item{to}{output format, one of 'html' or 'mml'}
+
+\item{display}{should the equation be in display (\code{TRUE}) or inline mode
+(\code{FALSE}, by default)}
 }
 \value{
 a character vector that contains 'html' or 'mml'


### PR DESCRIPTION
David,
I really enjoy {flextable}, but there is a bug in equations (see https://stackoverflow.com/questions/75259222/inline-equations-in-flextable) where they are in display mode for HTML rendering while they are rendered in inline mode for both PDF and DOCX (inline mode is more useful in the context).
One way to solve it is to allow to choose between display or inline mode in `transform_mathjax()` in {equatags} through a new argument `display =` that is set to `FALSE` by default (= generate inline equations) in this pull request. This way, no further change is required to {flextable} to solve the bug.