### PR TITLE
strict = "ignore" option added in transform_mathjax()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: equatags
 Type: Package
 Title: Equations to 'XML'
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("David", "Gohel", role = c("aut", "cre"),
     email = "david.gohel@ardata.fr"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# equatags 0.2.2
+
+- add a `strict` argument to transform_mathjax() ("ignore" by default) to turn off ennoying warnings when using accented characters in equations.
+
 # equatags 0.2.1
 
 - add a `display` argument to transform_mathjax() to allow generating display or inline equations. It is set to FALSE by default (inline equation). This changes the behaviour that was previously to generate display equations only.

--- a/R/write_mathjax.R
+++ b/R/write_mathjax.R
@@ -22,6 +22,9 @@ xml_header <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 #' @param to output format, one of 'html' or 'mml'
 #' @param display should the equation be in display (`TRUE`) or inline mode
 #' (`FALSE`, by default)
+#' @param strict KaTeX option.If `"ignore"` (default), allow features that make
+#' writing LaTeX convenient. Other options are `"warn"` or `"error"`. This
+#' happens E;G;, when you use accented characters in your equations.
 #' @return a character vector that contains 'html' or 'mml'
 #' codes corresponding to the equations.
 #' @examples
@@ -33,20 +36,21 @@ xml_header <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 #' cat(z, sep = "\n\n")
 #' @importFrom xml2 read_xml xml_children
 #' @importFrom katex katex_mathml katex_html
-transform_mathjax <- function(x, to = "html", display = FALSE){
+transform_mathjax <- function(x, to = "html", display = FALSE, strict = "ignore"){
 
   if(length(x) < 1) return(character(0))
   to <- match.arg(to, choices = c("html", "mml", "svg"), several.ok = FALSE)
+  strict <- match.arg(strict, choices = c("ignore", "warn", "error"), several.ok = FALSE)
 
   if ("mml" %in% to) {
-    info <- vapply(x, katex_mathml, "", preview = FALSE)
+    info <- vapply(x, katex_mathml, "", preview = FALSE, strict = strict)
     names(info) <- NULL
     info <- gsub("</span>", "", info, fixed = TRUE)
     info <- gsub("<span class=\"katex\">", "", info, fixed = TRUE)
     info <- vapply(info, mml_to_ooml, FUN.VALUE = character(1L), USE.NAMES = FALSE)
   } else {
     info <- vapply(x, katex_html, "", preview = FALSE, include_css = TRUE,
-      displayMode = display)
+      displayMode = display, strict = strict)
     names(info) <- NULL
   }
 

--- a/man/transform_mathjax.Rd
+++ b/man/transform_mathjax.Rd
@@ -4,7 +4,7 @@
 \alias{transform_mathjax}
 \title{'MathJax' equation as 'HTML' or 'MathML'.}
 \usage{
-transform_mathjax(x, to = "html", display = FALSE)
+transform_mathjax(x, to = "html", display = FALSE, strict = "ignore")
 }
 \arguments{
 \item{x}{MathJax equations}
@@ -13,6 +13,10 @@ transform_mathjax(x, to = "html", display = FALSE)
 
 \item{display}{should the equation be in display (\code{TRUE}) or inline mode
 (\code{FALSE}, by default)}
+
+\item{strict}{KaTeX option.If \code{"ignore"} (default), allow features that make
+writing LaTeX convenient. Other options are \code{"warn"} or \code{"error"}. This
+happens E;G;, when you use accented characters in your equations.}
 }
 \value{
 a character vector that contains 'html' or 'mml'


### PR DESCRIPTION
Currently, when accented characters are used in equations, the KaTeX engine warns for each character. To test it, issue:

```
equatags::transform_mathjax("évènement = x^2")
```

This PR adds a `strict = "ignore"` argument to transform_mathjax(), that is transferred to KaTeX. It turns off these warnings. Nowadays, most people use xetex (default in Quarto) or luatex engines that accepts UTF-8 characters. Thus, it works well, and the warnings are just annoying.

It is still possible to turn on the warnings again with:

```
equatags::transform_mathjax("évènement = x^2", strict = "warn")
```